### PR TITLE
Pipeline ocl code conditionally supported

### DIFF
--- a/ff/pipeline.hpp
+++ b/ff/pipeline.hpp
@@ -35,7 +35,9 @@
 #include <ff/svector.hpp>
 #include <ff/fftree.hpp>
 #include <ff/node.hpp>
+#ifdef FF_OPENCL
 #include <ff/ocl/clEnvironment.hpp>
+#endif
 #if defined(MAMMUT)
 #include <mammut/mammut.hpp>
 #endif
@@ -409,12 +411,14 @@ public:
             }
             barrier->barrierSetup(nthreads);
 
+#ifdef FF_OPENCL
             // REMOVE THIS ?
             // check if we have to setup the OpenCL environment !
             if (fftree_ptr->hasOpenCLNode()) {
                 // setup openCL environment
                 clEnvironment::instance();
             }
+#endif
 
         }
         if (!prepared) if (prepare()<0) return -1;


### PR DESCRIPTION
On platforms without OCL pipeline.hpp should not depend on OCL. 

This PR solves two very minor issues:
- Conditionally include an ocl header file.
- Conditional code for setting up OCL environment.