### PR TITLE
Added missing dc.hpp to install list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(FFHEADERS
  ${FF}/buffer.hpp
  ${FF}/config.hpp
  ${FF}/cycle.h
+ ${FF}/dc.hpp
  ${FF}/dinout.hpp
  ${FF}/dnode.hpp
  ${FF}/dynlinkedlist.hpp


### PR DESCRIPTION
`dc.hpp` was missing from the list of files installed through cmake's install target.