### PR TITLE
fixing gcc/clang -Wextra warning in MacOS

### DIFF
--- a/ff/barrier.hpp
+++ b/ff/barrier.hpp
@@ -96,7 +96,7 @@ public:
         return 0;
     }
 
-    inline void doBarrier(size_t id) {
+    inline void doBarrier(size_t) {
         pthread_mutex_lock(&bLock);
         if (++counter == _barrier) {
             pthread_cond_broadcast(&bCond);

--- a/ff/buffer.hpp
+++ b/ff/buffer.hpp
@@ -61,7 +61,7 @@
 #include <ff/config.hpp>
 
 #if defined(__APPLE__)
-#include <AvailabilityMacros.h>
+#include <Availability.h>
 #endif
 
 #include <ff/platforms/platform.h>

--- a/ff/config.hpp
+++ b/ff/config.hpp
@@ -220,7 +220,7 @@
 #endif 
 
 #if defined(__APPLE__)
-#include <AvailabilityMacros.h>
+#include <Availability.h>
 #if defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= 1050)
 #define MAC_OS_X_HAS_AFFINITY 1
 #else

--- a/ff/dc.hpp
+++ b/ff/dc.hpp
@@ -571,7 +571,7 @@ public:
     }
     ff_DC(const std::function<void (const OperandType&, std::vector<OperandType> &)>& divide_fn, const std::function<void(std::vector<ResultType>&,ResultType&)>& combine_fn,
         const std::function<void(const OperandType&, ResultType&)>& seq_fn, const std::function<bool(const OperandType&)>& cond_fn, int numw, 
-               size_t outstandingTasks=DEFAULT_OUTSTANDING_TASKS,int maxnw=ff_numCores(), void (*schedRelaxF)(unsigned long)=NULL):
+               size_t /*outstandingTasks*/=DEFAULT_OUTSTANDING_TASKS,int maxnw=ff_numCores(), void (*schedRelaxF)(unsigned long)=NULL):
                                _divide_fn(divide_fn), _combine_fn(combine_fn), _seq_fn(seq_fn), _condition_fn(cond_fn)
     {
 

--- a/ff/mapping_utils.hpp
+++ b/ff/mapping_utils.hpp
@@ -511,6 +511,8 @@ static inline ssize_t ff_mapThreadToCpu(int cpu_id, int priority_level=0) {
     }
     //std::cerr << "Successfully set affinity of thread " << GetCurrentThreadId() << " to core " << cpu_id << "\n";
 #else 
+FF_IGNORE_UNUSED(cpu_id);
+FF_IGNORE_UNUSED(priority_level);
 #warning "CPU_SET not defined, cannot map thread to specific CPU"
 #endif
     return 0;

--- a/ff/parallel_for_internals.hpp
+++ b/ff/parallel_for_internals.hpp
@@ -356,6 +356,7 @@ namespace ff {
     auto idtt_##name =identity;                                                          \
     auto F_##name =[&](const long ff_start_##idx, const long ff_stop_##idx,              \
                        const int _ff_thread_id, decltype(var) &var) {                    \
+        FF_IGNORE_UNUSED(_ff_thread_id);                                                 \
         const long _ff_jump0=(name->getnw())*(-chunk*step);                              \
         const long _ff_jump1=(-chunk*step);                                              \
         PRAGMA_IVDEP;                                                                    \

--- a/ff/sysdep.h
+++ b/ff/sysdep.h
@@ -38,7 +38,7 @@
 #define FF_SPIN_SYSDEP_H
 
 #if defined(__APPLE__)
-#include <AvailabilityMacros.h>
+#include <Availability.h>
 #endif
 
 

--- a/ff/utils.hpp
+++ b/ff/utils.hpp
@@ -155,6 +155,9 @@ static inline int memory_Stats(const std::string &status, size_t &vm, size_t &vm
     f.close();
     return 0;
 #else
+    FF_IGNORE_UNUSED(status);
+    FF_IGNORE_UNUSED(vm);
+    FF_IGNORE_UNUSED(vmp);
     error("memory_Stats, not implemented for this platform\n");
     return -1;
 #endif

--- a/tests/test_combine13.cpp
+++ b/tests/test_combine13.cpp
@@ -52,8 +52,6 @@
 
 using namespace ff;
 
-const long WORKTIME_TICKS=25000;
-
 struct Generator: ff_node_t<long> {
     Generator(long ntasks):ntasks(ntasks) {}
     long *svc(long *) {

--- a/tests/test_combine14.cpp
+++ b/tests/test_combine14.cpp
@@ -53,8 +53,6 @@
 
 using namespace ff;
 
-const long WORKTIME_TICKS=25000;
-
 struct Generator: ff_node_t<long> {
     Generator(long ntasks):ntasks(ntasks) {}
     long *svc(long *) {

--- a/tests/test_optimize5.cpp
+++ b/tests/test_optimize5.cpp
@@ -106,7 +106,7 @@ struct PipeWorker: ff_pipeline {
     }
 
 
-    long* svc(long*) { abort();}
+    void* svc(void*) { abort(); }
 };
 
 


### PR DESCRIPTION
Remove some warning in the ifdef parts of Apple and change the AvailabilityMacros.h header with the newer Availability.h.