### PR TITLE
Enhance portability by replacing platform-dependent code with C++11

### DIFF
--- a/BUILD.ME
+++ b/BUILD.ME
@@ -99,6 +99,7 @@ Currently tested with Visual Studio 2013
 -DTRACE_FASTFLOW      --> perfomance analysis (default off)
 -DBLOCKING_MODE       --> enable blocking run-time (default off)
 -DNO_CMAKE_CONFIG     --> use static configuration (experimental)
+-DFF_NONPORTABLE_IMPL --> use legacy, non portable implementation (default off)
 
 =======================================================
 Compilation instructions for OpenCL denoiser example

--- a/ff/buffer.hpp
+++ b/ff/buffer.hpp
@@ -56,7 +56,9 @@
 
 #include <cstdlib>
 #include <cstring>
-//#include <atomic>
+#ifdef USE_CPP_FENCE
+#include <atomic>
+#endif
 //#include <ff/atomic/abstraction_dcas.h>
 
 #include <ff/sysdep.h>
@@ -250,8 +252,11 @@ public:
              * memory model where stores can be executed out-or-order 
              * (e.g. Powerpc). This is a no-op on Intel x86/x86-64 CPUs.
              */
-            WMB(); 
-            //std::atomic_thread_fence(std::memory_order_release);
+#ifndef USE_CPP_FENCE
+            WMB();
+#else
+            std::atomic_thread_fence(std::memory_order_release);
+#endif
             buf[pwrite] = data;
             pwrite = pwrite + ((pwrite+1 >=  size) ? (1-size): 1); // circular buffer
             return true;

--- a/ff/config.hpp
+++ b/ff/config.hpp
@@ -220,6 +220,14 @@
 #endif
 
 
+// If the following is defined, then pthreads and assembly memory barriers are used
+// instead of C++11 threads and memory fences.
+#if !defined(FF_NONPORTABLE_IMPL)
+#define USE_CPP_THREADS
+#define USE_CPP_FENCE
+#endif
+
+
 // TODO:
 //#if defined(NO_CMAKE_CONFIG)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -62,7 +62,10 @@ endif
 #                       string, please use the 'mapping_string.sh' script
 #                       contained in the ff directory.
 #
-###############################à#############################################
+# -DFF_NONPORTABLE_IMPL Pthreads and assembly memory barriers are used
+#                       instead of C++11 threads and memory fences.
+#
+#############################################################################
 #CC                 ?= gcc
 #CXX                ?= g++ -std=c++17 #-DBLOCKING_MODE -DDEFAULT_BUFFER_CAPACITY=32768 -DFF_BOUNDED_BUFFER
 #CC                 ?= icc  -mmic
@@ -93,6 +96,9 @@ ifdef TRACE_FASTFLOW
 endif
 ifdef DEFAULT_BUFFER_CAPACITY
     CXXFLAGS        += -DDEFAULT_BUFFER_CAPACITY=${DEFAULT_BUFFER_CAPACITY}
+endif
+ifdef FF_NONPORTABLE_IMPL
+    CXXFLAGS        += -DFF_NONPORTABLE_IMPL
 endif
 ifdef USE_CPP_THREADS
     CXXFLAGS        += -DUSE_CPP_THREADS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -94,6 +94,9 @@ endif
 ifdef DEFAULT_BUFFER_CAPACITY
     CXXFLAGS        += -DDEFAULT_BUFFER_CAPACITY=${DEFAULT_BUFFER_CAPACITY}
 endif
+ifdef USE_CPP_THREADS
+    CXXFLAGS        += -DUSE_CPP_THREADS
+endif
 CXXFLAGS            += -DNO_CMAKE_CONFIG -Wall
 INCS                 = -I.. 
 LIBS                 = -pthread

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -97,6 +97,9 @@ endif
 ifdef USE_CPP_THREADS
     CXXFLAGS        += -DUSE_CPP_THREADS
 endif
+ifdef USE_CPP_FENCE
+    CXXFLAGS        += -DUSE_CPP_FENCE
+endif
 CXXFLAGS            += -DNO_CMAKE_CONFIG -Wall
 INCS                 = -I.. 
 LIBS                 = -pthread


### PR DESCRIPTION
- Thread creation now uses `std::thread` instead of `pthreads`.
- SPSC channel synchronization now relies on `std::atomic_thread_fence`, replacing the non-portable assembly `WMB`.

The previous implementation is preserved and can be restored by defining the `FF_NONPORTABLE_IMPL` macro.